### PR TITLE
商品詳細表示機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 | status_id         | integer   | null: false        |
 | delivery_fee_id   | integer   | null: false        |
 | area_id           | integer   | null: false        |
-| days_id           | integer   | null: false        |
+| day_id           | integer   | null: false        |
 | price             | integer   | null: false        |
 | user              | references| foreign_key: true: |
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,7 +9,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item=Item.find(params[:id])
+    @item = Item.find(params[:id])
   end
 
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,6 +24,6 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :data, :category_id, :image, :status_id, :delivery_fee_id, :area_id, :days_id, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :data, :category_id, :image, :status_id, :delivery_fee_id, :area_id, :day_id, :price).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,7 +15,7 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to root_path
+      render :show
     else
       render :new
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,6 +8,10 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def show
+    @item=Item.find(params[:id])
+  end
+
   def create
     @item = Item.new(item_params)
     if @item.save

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,7 +9,7 @@ class Item < ApplicationRecord
     validates :status_id
     validates :delivery_fee_id
     validates :area_id
-    validates :days_id
+    validates :day_id
     validates :image
     validates :price
   end
@@ -19,7 +19,7 @@ class Item < ApplicationRecord
     validates :status_id
     validates :delivery_fee_id
     validates :area_id
-    validates :days_id
+    validates :day_id
   end
 
   validates :price, format: { with: /\A[0-9]+\z/, message: '半角数字で入力して下さい' }

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,7 +126,7 @@
     <ul class='item-lists'>
       <% @item.each do |item| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -72,7 +72,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:days_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:day_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -100,7 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price%>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.delivery_fee.name %>
       </span>
     </div>
 
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.data %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,18 +23,18 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% end %>
 
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% if user_signed_in? && current_user.id != @item.user_id%>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.data %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,9 +27,7 @@
         <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% end %>
-
-    <% if user_signed_in? && current_user.id != @item.user_id%>
+    <% elsif user_signed_in? && current_user.id != @item.user_id%>
         <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
         <%# //商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only:[:new,:create]
+  resources :items, only:[:new,:create,:show]
 end

--- a/db/migrate/20201205120954_create_items.rb
+++ b/db/migrate/20201205120954_create_items.rb
@@ -9,7 +9,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :status_id,null: false
       t.integer :delivery_fee_id,null: false
       t.integer :area_id,null: false
-      t.integer :days_id,null:false
+      t.integer :day_id,null:false
       t.integer :price,null:false
       t.references :user,foreign_key: true
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2020_12_06_084513) do
     t.integer "status_id", null: false
     t.integer "delivery_fee_id", null: false
     t.integer "area_id", null: false
-    t.integer "days_id", null: false
+    t.integer "day_id", null: false
     t.integer "price", null: false
     t.bigint "user_id"
     t.index ["user_id"], name: "index_items_on_user_id"

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -6,8 +6,8 @@ FactoryBot.define do
     status_id             { 2 }
     delivery_fee_id       { 2 }
     area_id               { 2 }
-    day_id               { 2 }
-    price                 { 10_000 }
+    day_id { 2 }
+    price { 10_000 }
     association :user
 
     after(:build) do |item|

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     status_id             { 2 }
     delivery_fee_id       { 2 }
     area_id               { 2 }
-    days_id               { 2 }
+    day_id               { 2 }
     price                 { 10_000 }
     association :user
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -77,16 +77,16 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Area must be other than 1')
       end
 
-      it 'days_idが空ではいけない' do
-        @item.days_id = ''
+      it 'day_idが空ではいけない' do
+        @item.day_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Days can't be blank")
+        expect(@item.errors.full_messages).to include("Day can't be blank")
       end
 
-      it 'days_idが1ではいけない' do
-        @item.days_id = '1'
+      it 'day_idが1ではいけない' do
+        @item.day_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Days must be other than 1')
+        expect(@item.errors.full_messages).to include('Day must be other than 1')
       end
 
       it 'priceが空ではいけない' do


### PR DESCRIPTION
#what　
商品の詳細画面実装
#why
詳細、削除、編集、購入のため
ユーザーが自分の商品詳細に行くと編集、削除のみある
https://gyazo.com/a8ae624205de7161d306bf73f6a256de
未ログインは詳細へ行ってもボタンがない
https://gyazo.com/44bf25146b47890b82583a40bc2a037c
ログインユーザーは他人の詳細に購入ボタンのみある
https://gyazo.com/31987eb1bce74523a66391ec2ff10048